### PR TITLE
Add a simple Superset helm chart

### DIFF
--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+name: insights-superset
+description: FortressIQ Superset application for Kubernetes. Designed and running in production for Azure and GCP.
+icon: https://www.fortressiq.com/hubfs/identity/logos/FIQ-Logo-Icon.png
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 1.0.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 1.17.0

--- a/chart/cluster/tr-au-000/values.yaml
+++ b/chart/cluster/tr-au-000/values.yaml
@@ -31,15 +31,18 @@ ingress:
   tls:
     - secretName: superset-fortressiq
       hosts:
-        - tr-au-0000-superset.fortressiq.com
+        - tr-au-000-superset.fortressiq.com
 
 cloudenv:
-  azure: true
-  gcp: false
-  gcpzones: {}
+  azure: false
+  gcp: true
+  gcpzones:
+    - australia-southeast1-a
+    - australia-southeast1-b
+    - australia-southeast1-c
 
 persistent:
-  create: false
+  create: true
   # create only if new pvc is needed
   # defaults to re-use exisiting pvc
 

--- a/chart/cluster/tr-us-000/values.yaml
+++ b/chart/cluster/tr-us-000/values.yaml
@@ -1,0 +1,67 @@
+# Default values for fiq-insights-superset.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: gcr.io/trinity-dev-200016/github-fortressiq-superset-custom:latest
+  pullPolicy: Always
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podSecurityContext:
+  fsGroup: 1000
+  runAsUser: 1000
+
+service:
+  type: NodePort
+  port: 9000
+
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: "tr-au-000-superset"
+    networking.gke.io/managed-certificates: "insight-a-certificate"
+  hosts:
+    - host: tr-au-000-superset.fortressiq.com  
+      paths: []
+  tls:
+    - secretName: superset-fortressiq
+      hosts:
+        - tr-us-0000-superset.fortressiq.com
+
+cloudenv:
+  azure: true
+  gcp: false
+
+persistent:
+  create: false
+  # create only if new pvc is needed
+  # defaults to re-use exisiting pvc
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 750Mi
+  requests:
+    cpu: 50m
+    memory: 256Mi
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,4 +1,4 @@
-0. helm <release> test
+0. helm test <release> 
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,0 +1,22 @@
+0. helm <release> test
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "fiq-insights-superset.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "fiq-insights-superset.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "fiq-insights-superset.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "fiq-insights-superset.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 9000:443
+{{- end }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fiq-insights-superset.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fiq-insights-superset.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "fiq-insights-superset.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "fiq-insights-superset.labels" -}}
+helm.sh/chart: {{ include "fiq-insights-superset.chart" . }}
+{{ include "fiq-insights-superset.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "fiq-insights-superset.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "fiq-insights-superset.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "fiq-insights-superset.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "fiq-insights-superset.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/chart/templates/storage.yaml
+++ b/chart/templates/storage.yaml
@@ -53,9 +53,9 @@ allowedTopologies:
 - matchLabelExpressions:
   - key: failure-domain.beta.kubernetes.io/zone
     values:
-    - europe-west2-a
-    - europe-west2-b
-    - europe-west2-c    
+    {{- range .Values.cloudenv.gcpzones }}
+    - {{ . }}
+    {{- end }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/chart/templates/storage.yaml
+++ b/chart/templates/storage.yaml
@@ -43,7 +43,7 @@ spec:
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: standard
+  name: gcp-standard
   annotations:
     helm.sh/resource-policy: keep
 provisioner: kubernetes.io/gce-pd
@@ -64,7 +64,7 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
 spec:
-  storageClassName: standard
+  storageClassName: gcp-standard
   accessModes:
     - ReadWriteOnce
   resources:

--- a/chart/templates/storage.yaml
+++ b/chart/templates/storage.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.cloudenv.azure -}}
+  {{- if .Values.persistent.create -}}
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: standard
+provisioner: kubernetes.io/azure-disk
+parameters:
+  storageaccounttype: Standard_LRS
+  kind: Managed
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: superset-cf
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  storageClassName: standard
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 32Gi
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: insights-a-superset
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  storageClassName: standard
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 32Gi
+  {{- end }}
+{{- end }}
+{{- if .Values.cloudenv.gcp -}}
+  {{- if .Values.persistent.create -}}
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: standard
+  annotations:
+    helm.sh/resource-policy: keep
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-standard
+allowedTopologies:
+- matchLabelExpressions:
+  - key: failure-domain.beta.kubernetes.io/zone
+    values:
+    - europe-west2-a
+    - europe-west2-b
+    - europe-west2-c    
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: insights-a-superset
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  storageClassName: standard
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 32Gi
+  {{- end }}      
+{{- end }}

--- a/chart/templates/superset-ingress.yaml
+++ b/chart/templates/superset-ingress.yaml
@@ -29,7 +29,7 @@ spec:
         {{- range .paths }}
           - path: {{ . }}
             backend:
-              serviceName: insights-a-superset
+              serviceName: {{ include "fiq-insights-superset.fullname" . }}
               servicePort: {{ .Values.service.port }}
         {{- end }}
   {{- end }}

--- a/chart/templates/superset-ingress.yaml
+++ b/chart/templates/superset-ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled -}}
+{{- if .Values.persistent.create -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: superset-ingress-fortressiq
+  {{- with .Values.annotations }}
+  annotations:
+      {{- toYaml . | nindent 4 }}
+  {{- end }}  
+  labels:
+    app: superset
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: insights-a-superset
+              servicePort: {{ .Values.service.port }}
+        {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/chart/templates/superset-ingress.yaml
+++ b/chart/templates/superset-ingress.yaml
@@ -1,37 +1,46 @@
 {{- if .Values.ingress.enabled -}}
 {{- if .Values.persistent.create -}}
+{{- if .Values.cloudenv.gcp -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: superset-ingress-fortressiq
-  {{- with .Values.annotations }}
+  name: {{ include "fiq-insights-superset.fullname" . }}
+  {{- with .Values.ingress.annotations }}
   annotations:
       {{- toYaml . | nindent 4 }}
   {{- end }}  
   labels:
     app: superset
 spec:
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
-  {{- end }}
+  backend:
+    serviceName: {{ include "fiq-insights-superset.fullname" . }}
+    servicePort: {{ .Values.service.port }}
 {{- end }}
+{{- if .Values.cloudenv.azure -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "fiq-insights-superset.fullname" . }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+      {{- toYaml . | nindent 4 }}
+  {{- end }}  
+  labels:
+    app: superset
+spec:
   rules:
-  {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-        {{- range .paths }}
-          - path: {{ . }}
-            backend:
-              serviceName: {{ include "fiq-insights-superset.fullname" . }}
-              servicePort: {{ .Values.service.port }}
-        {{- end }}
-  {{- end }}
+  - host: {{ .Values.ingress.host }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ include "fiq-insights-superset.fullname" . }}
+          servicePort: {{ .Values.service.port }}
+  tls:
+  - hosts:
+    - {{ .Values.ingress.host }}
+    secretName: {{ .Values.ingress.tls.secretName }}
+
+{{- end }}
+
 {{- end }}
 {{- end }}

--- a/chart/templates/superset.yaml
+++ b/chart/templates/superset.yaml
@@ -9,7 +9,7 @@ metadata:
     app: superset
     release: insights-a  
     app.kubernetes.io/name: {{ include "fiq-insights-superset.fullname" . }}
-  name: insights-a-superset
+  name: {{ include "fiq-insights-superset.fullname" . }}
   resourceVersion: "133206134"
 spec:
   progressDeadlineSeconds: 600
@@ -105,7 +105,7 @@ metadata:
     app: superset
     release: insights-a
     app.kubernetes.io/name: {{ include "fiq-insights-superset.fullname" . }}
-  name: insights-a-superset
+  name: {{ include "fiq-insights-superset.fullname" . }}
   resourceVersion: "45926909"
 spec:
   externalTrafficPolicy: Cluster

--- a/chart/templates/superset.yaml
+++ b/chart/templates/superset.yaml
@@ -1,0 +1,121 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "3"
+  creationTimestamp: null
+  generation: 4
+  labels:
+    app: superset
+    release: insights-a  
+    app.kubernetes.io/name: {{ include "fiq-insights-superset.fullname" . }}
+  name: insights-a-superset
+  resourceVersion: "133206134"
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: superset
+      release: insights-a
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/secrets: 13188d8d682bead91edbb2dd1a7202148cd614e62b61b686a6d5f787272f65e3
+      creationTimestamp: null
+      labels:
+        app: superset
+        release: insights-a
+        app.kubernetes.io/name: {{ include "fiq-insights-superset.fullname" . }}
+      name: insights-a-superset
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 4 }}
+    {{- end }}
+      containers:
+      - args:
+        - /fiq-init.sh
+        command:
+        - /bin/bash
+        image:  "{{ .Values.image.repository }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        livenessProbe:
+          failureThreshold: 2
+          httpGet:
+            path: /health
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 80
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: superset
+        ports:
+        - containerPort: 8088
+          name: http
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 2
+          httpGet:
+            path: /health
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        {{- with .Values.imagePullSecrets }}
+        resources:
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /home/superset
+          name: superset-configs
+        - mountPath: /var/lib/superset
+          name: storage-volume
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: superset-configs
+        secret:
+          defaultMode: 420
+          secretName: insights-a-superset
+      - name: storage-volume
+        persistentVolumeClaim:
+          claimName: insights-a-superset
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: superset
+    release: insights-a
+    app.kubernetes.io/name: {{ include "fiq-insights-superset.fullname" . }}
+  name: insights-a-superset
+  resourceVersion: "45926909"
+spec:
+  externalTrafficPolicy: Cluster
+  ports:
+  - name: http
+    port: {{ .Values.service.port }}
+    protocol: TCP
+    targetPort: 8088
+  selector:
+    app: superset
+    release: insights-a
+  sessionAffinity: None
+  type: {{ .Values.service.type }}

--- a/chart/templates/superset.yaml
+++ b/chart/templates/superset.yaml
@@ -91,7 +91,7 @@ spec:
       - name: superset-configs
         secret:
           defaultMode: 420
-          secretName: insights-a-superset
+          secretName: superset
       - name: storage-volume
         persistentVolumeClaim:
           claimName: insights-a-superset

--- a/chart/templates/superset.yaml
+++ b/chart/templates/superset.yaml
@@ -10,7 +10,6 @@ metadata:
     release: insights-a  
     app.kubernetes.io/name: {{ include "fiq-insights-superset.fullname" . }}
   name: {{ include "fiq-insights-superset.fullname" . }}
-  resourceVersion: "133206134"
 spec:
   progressDeadlineSeconds: 600
   replicas: 1
@@ -106,7 +105,6 @@ metadata:
     release: insights-a
     app.kubernetes.io/name: {{ include "fiq-insights-superset.fullname" . }}
   name: {{ include "fiq-insights-superset.fullname" . }}
-  resourceVersion: "45926909"
 spec:
   externalTrafficPolicy: Cluster
   ports:

--- a/chart/templates/tests/test-connection.yaml
+++ b/chart/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['insights-a-superset:{{ .Values.service.port }}']
+      args: ['{{ include "fiq-insights-superset.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never

--- a/chart/templates/tests/test-connection.yaml
+++ b/chart/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "fiq-insights-superset.fullname" . }}-test-connection"
+  labels:
+    {{- include "fiq-insights-superset.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['insights-a-superset:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -25,13 +25,9 @@ ingress:
   annotations:
     kubernetes.io/ingress.global-static-ip-name: "tr-au-000-superset"
     networking.gke.io/managed-certificates: "insight-a-certificate"
-  hosts:
-    - host: tr-au-000-superset.fortressiq.com  
-      paths: []
+  host: tr-au-000-superset.fortressiq.com
   tls:
-    - secretName: superset-fortressiq
-      hosts:
-        - tr-au-000-superset.fortressiq.com
+    secretName: superset-fortressiq
 
 cloudenv:
   azure: true

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,67 @@
+# Default values for fiq-insights-superset.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: gcr.io/trinity-dev-200016/github-fortressiq-superset-custom:latest
+  pullPolicy: Always
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podSecurityContext:
+  fsGroup: 1000
+  runAsUser: 1000
+
+service:
+  type: NodePort
+  port: 9000
+
+ingress:
+  enabled: false
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: "tr-au-000-superset"
+    networking.gke.io/managed-certificates: "insight-a-certificate"
+  hosts:
+    - host: tr-au-000-superset.fortressiq.com  
+      paths: []
+  tls:
+    - secretName: superset-fortressiq
+      hosts:
+        - tr-us-0000-superset.fortressiq.com
+
+cloudenv:
+  azure: true
+  gcp: false
+
+persistent:
+  create: false
+  # create only if new pvc is needed
+  # defaults to re-use exisiting pvc
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 750Mi
+  requests:
+    cpu: 50m
+    memory: 256Mi
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,6 +1,6 @@
 # Default values for fiq-insights-superset.
-# This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+# default is azure with existing ingress and persistent volume
 
 replicaCount: 1
 
@@ -31,7 +31,7 @@ ingress:
   tls:
     - secretName: superset-fortressiq
       hosts:
-        - tr-us-0000-superset.fortressiq.com
+        - tr-au-000-superset.fortressiq.com
 
 cloudenv:
   azure: true


### PR DESCRIPTION
- Running in Walmart US (Azure)  and AU (GCP)
- Uses values.yaml to connect to existing persistent volume claim and existing ingress or create new
- see: https://tr-us-0000-superset.fortressiq.com/

$ helm upgrade --install  -f cluster/tr-us-000/values.yaml fiqsup .
NAME: fiqsup
LAST DEPLOYED: Tue Mar 24 16:30:24 2020
NAMESPACE: default
STATUS: deployed
REVISION: 2
NOTES:
0. helm <release> test
1. Get the application URL by running these commands:
  export NODE_PORT=$(kubectl get --namespace default -o jsonpath="{.spec.ports[0].nodePort}" services fiqsup-insights-superset)
  export NODE_IP=$(kubectl get nodes --namespace default -o jsonpath="{.items[0].status.addresses[0].address}")
  echo http://$NODE_IP:$NODE_PORT